### PR TITLE
Publish script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "release:patch": "npm version patch",
     "release:minor": "npm version minor",
     "release:major": "npm version major",
-    "publish": "npm run build && release patch"
+    "prepublishOnly": "npm run build && release patch"
   },
   "dependencies": {
     "pilasweb": "^0.5.0"


### PR DESCRIPTION
Ahora con `npm publish`, se corre todo lo necesario para publicar (buildear, subir versión y subir a node).