### PR TITLE
Bug - lata gigante

### DIFF
--- a/src/comportamientos/Achicar.ts
+++ b/src/comportamientos/Achicar.ts
@@ -6,7 +6,7 @@ class Achicar extends ComportamientoAnimado {
   private contador: number
 
   elReceptorSeAchico(): boolean {
-    return this.receptor.getAncho() <= 1
+    return this.receptor.getAncho() <= 1 || this.receptor.getAlto() <= 1
   }
 
   /**

--- a/src/comportamientos/Achicar.ts
+++ b/src/comportamientos/Achicar.ts
@@ -24,9 +24,9 @@ class Achicar extends ComportamientoAnimado {
     }
 
     else {
-      this.contador = (this.contador + this.velocidad) 
-      this.receptor.setAlto(this.receptor.getAlto() - this.contador);
-      this.receptor.setAncho(this.receptor.getAncho() - this.contador);
+      this.contador = (this.contador + this.velocidad)
+      this.receptor.setAlto(Math.max(0, this.receptor.getAlto() - this.contador));
+      this.receptor.setAncho(Math.max(0, this.receptor.getAncho() - this.contador));
       
       if (this.elReceptorSeAchico()) {
         this.receptor.eliminar()


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques-app/issues/232

¿Qué estaba pasando :thinking:? 

El código que se usaba en cualquier ejercicio que tenga _recoger lata_ es este:

https://github.com/Program-AR/pilas-bloques-exercises/blob/e9e2da7871c2d7f1132fe5e33169cdee6a907066/src/comportamientos/RecojoLata.ts#L15-L19

Achicar implica que suceda esto:

https://github.com/Program-AR/pilas-bloques-exercises/blob/e9e2da7871c2d7f1132fe5e33169cdee6a907066/src/comportamientos/Achicar.ts#L27-L33

Y la forma en que se fija si ya se achico es esta:

https://github.com/Program-AR/pilas-bloques-exercises/blob/e9e2da7871c2d7f1132fe5e33169cdee6a907066/src/comportamientos/Achicar.ts#L8-L10

Esto funciona bien siempre y cuando la diferencia entre el ancho y alto de la lata sea poca (caso que asumo sucede en los demás ejercicios de Capy recogiendo latas). **Pero** cuando el ancho es _bastante mayor al alto_, lo que pasa es que al momento en que el alto es menor a 1, como el ancho todavía no lo es **sigue restando el valor del contador**:

![imagen](https://github.com/Program-AR/pilas-bloques-exercises/assets/48812037/2328beae-2a70-4e19-a2a6-85d75be3cef7)

Como se puede ver en la imagen, cuando el alto llega a menos de 1, pero el ancho todavía no, hace la cuenta que resulta en aprox `-1,824` (valor que queda positivo al setearse el alto). 

Si bien el objeto ya debería haber desaparecido, el contador sigue aumentando hasta que el ancho también quede en menor a 1, pero al momento en que debería llegar, la resta termina dando también negativa y menor a -1, haciendo que nunca se cumpla `elReceptorSeAchico`.

Por esto es que se solucionaba si se le sacaba una de las filas del mapa: cambiaba el alto y el ancho de las latas lo suficiente para que no haya demasiada diferencia entre el ancho y el alto y zafara del bug.


Cambiando el método que dice si se achica para que chequee el alto además del alto, no debería pasar esto de nuevo, sin embargo habría que tener en cuenta a futuro si se vuelve a usar `Achicar` que la velocidad no sea demasiado alta para que suceda de nuevo el tema de que se reste de más. Para que no pase eso, también agregué el **max(0, resta)**, cosa que si es negativo siempre quede en 0, haciendo que no hayan chances de que vuelva a pasar el bug.

Así se ve el ejercicio con la solución que nos mandaron:

![capy](https://github.com/Program-AR/pilas-bloques-exercises/assets/48812037/6d889561-90ef-4ec4-98fe-c53fc0ab68f1)

